### PR TITLE
doc edits for ACS policy change and Fedora prerequisite installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ cd ..
 ./demo.sh start
 ```
 
-NOTE: This pipeline will fail if you don't [disable the "Fixable at least Important"](docs/disable_policy_enforcement.md) policy enforcement behaviour of ACS. This is expected to demonstrate the failure when a violation of the system policy occurs.
+NOTE: This pipeline will fail if you don't [disable the "Fixable Severity at least Important"](docs/disable_policy_enforcement.md) policy enforcement behaviour of ACS. This is expected to demonstrate the failure when a violation of the system policy occurs. Without disabling this policy (or at least changing the behaviour from "inform and enforce" to just "inform"), the image-check stage of the pipeline will fail (and break the build).
 
 ## Quick Video with the Demo
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Install some extra Python dependency:
 pip3 install jmespath
 ```
 
+* On Fedora workstations/servers, these prequisities can be fulfilled with the following single command:
+
+```sh
+sudo dnf install -y git ansible ansible-collection-kubernetes-core python3-kubernetes python3-openshift python3-jmespath jq
+```
+
+
 ## Bootstrap
 
 Fully automated deployment and integration of every resource and tool needed for this demo.

--- a/docs/disable_policy_enforcement.md
+++ b/docs/disable_policy_enforcement.md
@@ -1,10 +1,22 @@
 ## Disable the Policy Enforcement
 
-To disable the policy enforcement you need to:
+To disable the policy enforcement:
 
-- Go to the ACS Console 
-- Platform Configuration Tab
-- System Policies
-- Fixable CVSS >= 7 
-- Edit -> Next -> Next -> Next 
-- Build and Deploy into Enforcement Behavior Off
+- Login to ACS console.
+- Expand the "Platform Configuration" tab.
+- Select "Policy Management".
+- Click on the 3 vertical dots at the right of the target policy.
+
+EITHER
+
+- Click "Disable policy".
+
+OR
+
+- Click "Edit policy".
+- Click "Next" to skip "1 Policy details".
+- At "2 Policy behavior", scroll down to "Response method". Click "Inform" radio button instead of "Inform and enforce". Click "Next".
+- Click "Next" to skip "3 Policy criteria".
+- Click "Next" to skip "4 Policy scope".
+- Click "Save" at "5 Review policy" to save the updated policy configuration.
+- Click "5 Review policy".


### PR DESCRIPTION
Updated the ACS policy doc and added command for Fedora prerequisite installs.